### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Note: Keep your AWS credentials secure and never commit them to version control.
 To install AWS Resources MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/mcp-server-aws-resources-python):
 
 ```bash
-npx @smithery/cli install mcp-server-aws-resources-python --client claude
+npx -y @smithery/cli install mcp-server-aws-resources-python --client claude
 ```
 
 ### Docker Installation

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AWS Resources MCP Server
 
+[![smithery badge](https://smithery.ai/badge/mcp-server-aws-resources-python)](https://smithery.ai/server/mcp-server-aws-resources-python)
+
 ## Overview
 
 A Model Context Protocol (MCP) server implementation that provides running generated python code to query any AWS resources through boto3.
@@ -117,6 +119,14 @@ The following environment variables are required:
 You can also use a profile stored in the `~/.aws/credentials` file. To do this, set the `AWS_PROFILE` environment variable to the profile name.
 
 Note: Keep your AWS credentials secure and never commit them to version control.
+
+### Installing via Smithery
+
+To install AWS Resources MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/mcp-server-aws-resources-python):
+
+```bash
+npx @smithery/cli install mcp-server-aws-resources-python --client claude
+```
 
 ### Docker Installation
 

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,28 @@
+# Smithery configuration file: https://smithery.ai/docs/deployments
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - awsAccessKeyId
+      - awsSecretAccessKey
+    properties:
+      awsAccessKeyId:
+        type: string
+        description: Your AWS access key
+      awsSecretAccessKey:
+        type: string
+        description: Your AWS secret key
+      awsSessionToken:
+        type: string
+        description: AWS session token if using temporary credentials
+      awsDefaultRegion:
+        type: string
+        default: us-east-1
+        description: AWS region
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({command:'docker',args:['run','-i','--rm','-e',`AWS_ACCESS_KEY_ID=${config.awsAccessKeyId}`,'-e',`AWS_SECRET_ACCESS_KEY=${config.awsSecretAccessKey}`,'-e',`AWS_DEFAULT_REGION=${config.awsDefaultRegion}`,'baryhuang/mcp-server-aws-resources:latest']})


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML configuration file, which specifies how to start the MCP and what configuration options it supports. This enables hosting the MCP server on [Smithery](https://smithery.ai) and allows users to connect to the hosted version over SSE without additional dependencies. You may deploy your server by visiting your [server page](https://smithery.ai/server/mcp-server-aws-resources-python) and claiming it.
- **README**: Updates the README to include a popularity badge.

Please review these updates to verify their accuracy for your server. Let us know if you have any questions. 🙂